### PR TITLE
chore: add tests, deno format and deno lint 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ coverage
 .nyc_output
 package-lock.json
 yarn.lock
+.vscode

--- a/src/lib/isCreditCard.ts
+++ b/src/lib/isCreditCard.ts
@@ -11,12 +11,12 @@ export default function isCreditCard(str: string): boolean {
   let tmpNum: number;
   let shouldDouble: boolean = false;
   for (let i = sanitized.length - 1; i >= 0; i--) {
-    digit = sanitized.substring(i, (i + 1));
+    digit = sanitized.substring(i, i + 1);
     tmpNum = parseInt(digit, 10);
     if (shouldDouble) {
       tmpNum *= 2;
       if (tmpNum >= 10) {
-        sum += ((tmpNum % 10) + 1);
+        sum += (tmpNum % 10) + 1;
       } else {
         sum += tmpNum;
       }

--- a/src/lib/isIBAN.ts
+++ b/src/lib/isIBAN.ts
@@ -104,18 +104,18 @@ function hasValidIbanFormat(str: string): boolean {
 }
 
 /**
-   * Check whether string has valid IBAN Checksum
-   * by performing basic mod-97 operation and
-   * the remainder should equal 1
-   * -- Start by rearranging the IBAN by moving the four initial characters to the end of the string
-   * -- Replace each letter in the string with two digits, A -> 10, B = 11, Z = 35
-   * -- Interpret the string as a decimal integer and
-   * -- compute the remainder on division by 97 (mod 97)
-   * Reference: https://en.wikipedia.org/wiki/International_Bank_Account_Number
-   *
-   * @param {string} str
-   * @return {boolean}
-   */
+ * Check whether string has valid IBAN Checksum
+ * by performing basic mod-97 operation and
+ * the remainder should equal 1
+ * -- Start by rearranging the IBAN by moving the four initial characters to the end of the string
+ * -- Replace each letter in the string with two digits, A -> 10, B = 11, Z = 35
+ * -- Interpret the string as a decimal integer and
+ * -- compute the remainder on division by 97 (mod 97)
+ * Reference: https://en.wikipedia.org/wiki/International_Bank_Account_Number
+ *
+ * @param {string} str
+ * @return {boolean}
+ */
 function hasValidIbanChecksum(str: string): boolean {
   const strippedStr = str.replace(/[^A-Z0-9]+/gi, "").toUpperCase(); // Keep only digits and A-Z latin alphabetic
   const rearranged = strippedStr.slice(4) + strippedStr.slice(0, 4);

--- a/src/lib/isISIN.ts
+++ b/src/lib/isISIN.ts
@@ -15,7 +15,7 @@ export default function isISIN(str: string): boolean {
   let tmpNum: number;
   let shouldDouble = true;
   for (let i = checksumStr.length - 2; i >= 0; i--) {
-    digit = checksumStr.substring(i, (i + 1));
+    digit = checksumStr.substring(i, i + 1);
     tmpNum = parseInt(digit, 10);
     if (shouldDouble) {
       tmpNum *= 2;

--- a/src/lib/isIdentityCard.ts
+++ b/src/lib/isIdentityCard.ts
@@ -91,7 +91,7 @@ const validators: { [key: string]: Function } = {
       .reverse();
 
     invertedArray.forEach((val, i) => {
-      c = d[c][p[(i % 8)][val]];
+      c = d[c][p[i % 8][val]];
     });
 
     return c === 0;
@@ -330,20 +330,20 @@ const validators: { [key: string]: Function } = {
     if (!/^[A-Z][0-9]{9}$/.test(sanitized)) return false;
 
     return Array.from(sanitized).reduce(
-      (acc: number, currElement: string, index: number) => {
-        if (index === 0) {
-          const code = ALPHABET_CODES[currElement];
-          return ((code % 10) * 9) + Math.floor(code / 10);
-        }
+        (acc: number, currElement: string, index: number) => {
+          if (index === 0) {
+            const code = ALPHABET_CODES[currElement];
+            return ((code % 10) * 9) + Math.floor(code / 10);
+          }
 
-        if (index === 9) {
-          return ((10 - (acc % 10)) - Number(currElement)) % 10 === 0 ? 1 : 0;
-        }
+          if (index === 9) {
+            return ((10 - (acc % 10)) - Number(currElement)) % 10 === 0 ? 1 : 0;
+          }
 
-        return acc + (Number(currElement) * (9 - index));
-      },
-      0,
-    )
+          return acc + (Number(currElement) * (9 - index));
+        },
+        0,
+      )
       ? true
       : false;
   },

--- a/src/lib/isRgbColor.ts
+++ b/src/lib/isRgbColor.ts
@@ -1,3 +1,11 @@
+interface Options {
+  includePercentValues: boolean;
+}
+
+const defaultOptions: Options = {
+  includePercentValues: true,
+};
+
 const rgbColor: RegExp =
   /^rgb\((([0-9]|[1-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5]),){2}([0-9]|[1-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])\)$/;
 const rgbaColor: RegExp =
@@ -9,9 +17,9 @@ const rgbaColorPercent: RegExp =
 
 export default function isRgbColor(
   str: string,
-  includePercentValues = true,
+  options: Options = defaultOptions,
 ): boolean {
-  if (!includePercentValues) {
+  if (!options.includePercentValues) {
     return rgbColor.test(str) || rgbaColor.test(str);
   }
 

--- a/test/test-template.ts
+++ b/test/test-template.ts
@@ -9,7 +9,7 @@ interface Options {
   valid?: string[];
   invalid?: string[];
   error?: string[];
-  args?: (number | string | { [key: string]: any })[];
+  args?: (number | string | RegExp | Array<unknown> | { [key: string]: unknown })[];
 }
 
 export default function test(options: Options): void {
@@ -17,7 +17,7 @@ export default function test(options: Options): void {
     options.validator +
       (options.args ? " " + JSON.stringify(options.args) : ""),
     function (): void {
-      let args = options.args || [];
+      const args = options.args || [];
       if (options.valid) {
         options.valid.forEach((valid) => {
           assertEquals(validator[options.validator](valid, ...args), true);

--- a/test/test.ts
+++ b/test/test.ts
@@ -26,7 +26,7 @@ test({
   invalid: ["Abc", "123"],
 });
 
-({
+test({
   validator: "equals",
   args: ["abc ", { trim: true }],
   valid: ["  abc  "],
@@ -4134,6 +4134,29 @@ test({
 });
 
 test({
+  validator: "isMACAddress",
+  args: [{no_colons: true}],
+  valid: [
+    "abababababab",
+    "FFFFFFFFFFFF",
+    "0102030405ab",
+    "01AB03040506",
+    "A9C5D49FEBD3",
+
+  ],
+  invalid: [
+    "ab:ab:ab:ab:ab:ab",
+    "FF:FF:FF:FF:FF:FF",
+    "01:02:03:04:05:ab",
+    "01:AB:03:04:05:06",
+    "A9 C5 D4 9F EB D3",
+    "01 02 03 04 05 ab",
+    "01-02-03-04-05-ab",
+    "0102.0304.05ab",
+  ],
+});
+
+test({
   validator: "isMagnetURI",
   valid: [
     "magnet:?xt=urn:btih:06E2A9683BF4DA92C73A661AC56F0ECC9C63C5B4&dn=helloword2000&tr=udp://helloworld:1337/announce",
@@ -7173,6 +7196,19 @@ test({
     "rgba(3,3,3%,.3)",
     "rgb(101%,101%,101%)",
     "rgba(3%,3%,101%,0.3)",
+  ],
+});
+
+test({
+  validator: "isRgbColor",
+  args: [{includePercentValues: false}],
+  valid: [
+    "rgb(5,5,5)",
+    "rgba(5,5,5,.3)",
+  ],
+  invalid: [
+    "rgb(4,4,5%)",
+    "rgba(5%,5%,5%)",
   ],
 });
 

--- a/test/test.ts
+++ b/test/test.ts
@@ -4135,14 +4135,13 @@ test({
 
 test({
   validator: "isMACAddress",
-  args: [{no_colons: true}],
+  args: [{ no_colons: true }],
   valid: [
     "abababababab",
     "FFFFFFFFFFFF",
     "0102030405ab",
     "01AB03040506",
     "A9C5D49FEBD3",
-
   ],
   invalid: [
     "ab:ab:ab:ab:ab:ab",
@@ -7201,7 +7200,7 @@ test({
 
 test({
   validator: "isRgbColor",
-  args: [{includePercentValues: false}],
+  args: [{ includePercentValues: false }],
   valid: [
     "rgb(5,5,5)",
     "rgba(5,5,5,.3)",


### PR DESCRIPTION
- add test case for `isMacAddress` `{ no_colons: true }`
- add test case for `isRgbColor` `{ includePercentValues: false }`
  - BREAKING: used options object for `isRgbColor()` arg: `includePercentValues`
- fix test case for `equals`
- ran deno fmt
- fixed deno lint issues in test directory